### PR TITLE
feat(cli): add global options for CLI skeleton

### DIFF
--- a/matcha/cli.py
+++ b/matcha/cli.py
@@ -33,9 +33,10 @@ def cli(ctx, verbose, output, no_color):
     ctx.obj["output"] = output
 
     # Honour --no-color flag and NO_COLOR env var (see https://no-color.org/)
-    if no_color or os.environ.get("NO_COLOR", "") != "":
+    color_disabled = no_color or os.environ.get("NO_COLOR", "") != ""
+    if color_disabled:
         ctx.color = False
-    ctx.obj["no_color"] = no_color or os.environ.get("NO_COLOR", "") != ""
+    ctx.obj["no_color"] = color_disabled
 
     # Configure logging: messages go to stderr so stdout stays clean for
     # structured output.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -50,9 +50,11 @@ def test_verbose_sets_debug_logging():
 
 def test_output_default_is_text():
     """Default output format should be text."""
+    obj = {}
     runner = CliRunner()
-    result = runner.invoke(cli, [])
+    result = runner.invoke(cli, [], obj=obj)
     assert result.exit_code == 0
+    assert obj.get("output") == "text"
 
 
 def test_output_json():
@@ -71,13 +73,17 @@ def test_output_invalid_choice():
 
 def test_no_color_flag():
     """--no-color flag should be accepted and respected."""
+    obj = {}
     runner = CliRunner()
-    result = runner.invoke(cli, ["--no-color"])
+    result = runner.invoke(cli, ["--no-color"], obj=obj)
     assert result.exit_code == 0
+    assert obj.get("no_color") is True
 
 
 def test_no_color_env_var():
     """NO_COLOR env var should disable color."""
+    obj = {}
     runner = CliRunner(env={"NO_COLOR": "1"})
-    result = runner.invoke(cli, [])
+    result = runner.invoke(cli, [], obj=obj)
     assert result.exit_code == 0
+    assert obj.get("no_color") is True


### PR DESCRIPTION
## Summary

- Add `-v`/`--verbose` flag that sets the root logger to DEBUG level
- Add `-o`/`--output` option supporting `text` (default) and `json` formats
- Add `--no-color` flag with `NO_COLOR` environment variable support (https://no-color.org/)
- Logging goes to stderr, structured output to stdout
- Show help when invoked with no subcommand
- Add 7 new tests covering all global options

Closes #5

## Test plan

- [x] `matcha --help` shows all global options (--verbose, --output, --no-color, --version, --help)
- [x] `matcha --version` works
- [x] `-v` sets root logger to DEBUG
- [x] `--no-color` respected
- [x] `NO_COLOR` env var respected
- [x] `--output json` accepted
- [x] Invalid `--output` value rejected
- [x] All 10 tests pass