### PR TITLE
feat(output): add text + JSON output formatter

### DIFF
--- a/matcha/output.py
+++ b/matcha/output.py
@@ -1,0 +1,80 @@
+"""Output formatter for attack results.
+
+Formats ``Dict[str, Any]`` payloads returned by attack ``execute()``
+methods as either human-readable text or raw JSON.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, Dict, List, Sequence
+
+
+def _is_table(value: Sequence[Any]) -> bool:
+    """Return True when *value* looks like a list of dicts with uniform keys."""
+    if not value or not isinstance(value, (list, tuple)):
+        return False
+    if not all(isinstance(row, dict) for row in value):
+        return False
+    keys = set(value[0].keys())
+    return all(set(row.keys()) == keys for row in value)
+
+
+def _format_table(rows: List[Dict[str, Any]]) -> str:
+    """Return a simple ASCII table for a list of dicts."""
+    if not rows:
+        return ""
+    headers = list(rows[0].keys())
+    col_widths = {h: len(str(h)) for h in headers}
+    for row in rows:
+        for h in headers:
+            col_widths[h] = max(col_widths[h], len(str(row.get(h, ""))))
+
+    header_line = "  ".join(str(h).ljust(col_widths[h]) for h in headers)
+    separator = "  ".join("-" * col_widths[h] for h in headers)
+    lines = [header_line, separator]
+    for row in rows:
+        lines.append("  ".join(str(row.get(h, "")).ljust(col_widths[h]) for h in headers))
+    return "\n".join(lines)
+
+
+def _format_text(data: Dict[str, Any]) -> str:
+    """Return a human-readable text representation of *data*."""
+    lines: list[str] = []
+    for key, value in data.items():
+        if isinstance(value, (list, tuple)) and _is_table(value):
+            lines.append(f"{key}:")
+            lines.append(_format_table(list(value)))
+        elif isinstance(value, dict):
+            lines.append(f"{key}:")
+            for sub_key, sub_value in value.items():
+                lines.append(f"  {sub_key}: {sub_value}")
+        else:
+            lines.append(f"{key}: {value}")
+    return "\n".join(lines)
+
+
+def format_output(data: Dict[str, Any], fmt: str = "text") -> None:
+    """Print *data* to stdout in the requested format.
+
+    Parameters
+    ----------
+    data:
+        Dictionary of results returned by an attack's ``execute()`` method.
+    fmt:
+        ``"text"`` for a human-readable summary or ``"json"`` for raw JSON.
+
+    Raises
+    ------
+    ValueError
+        If *fmt* is not ``"text"`` or ``"json"``.
+    """
+    if fmt == "json":
+        json.dump(data, sys.stdout, indent=2, default=str)
+        sys.stdout.write("\n")
+    elif fmt == "text":
+        sys.stdout.write(_format_text(data))
+        sys.stdout.write("\n")
+    else:
+        raise ValueError(f"Unsupported output format: {fmt!r}")

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1,0 +1,110 @@
+"""Tests for the matcha output formatter."""
+
+import json
+
+import pytest
+
+from matcha.output import format_output
+
+
+def test_format_text_key_value(capsys):
+    """Text mode prints key-value pairs."""
+    data = {"attack": "syn_flood", "packets_sent": 100, "status": "ok"}
+    format_output(data, fmt="text")
+    captured = capsys.readouterr()
+    assert "attack: syn_flood" in captured.out
+    assert "packets_sent: 100" in captured.out
+    assert "status: ok" in captured.out
+    # Nothing should leak to stderr
+    assert captured.err == ""
+
+
+def test_format_json_valid(capsys):
+    """JSON mode prints valid JSON to stdout."""
+    data = {"attack": "syn_flood", "packets_sent": 100}
+    format_output(data, fmt="json")
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert parsed == data
+    assert captured.err == ""
+
+
+def test_format_json_ends_with_newline(capsys):
+    """JSON output should end with a trailing newline."""
+    format_output({"a": 1}, fmt="json")
+    captured = capsys.readouterr()
+    assert captured.out.endswith("\n")
+
+
+def test_format_text_with_table(capsys):
+    """Text mode renders a list of dicts as a table."""
+    data = {
+        "results": [
+            {"host": "10.0.0.1", "port": 80, "state": "open"},
+            {"host": "10.0.0.2", "port": 443, "state": "closed"},
+        ]
+    }
+    format_output(data, fmt="text")
+    captured = capsys.readouterr()
+    assert "host" in captured.out
+    assert "10.0.0.1" in captured.out
+    assert "10.0.0.2" in captured.out
+    assert "---" in captured.out
+
+
+def test_format_text_with_nested_dict(capsys):
+    """Text mode renders nested dicts with indentation."""
+    data = {"config": {"target": "10.0.0.1", "timeout": 30}}
+    format_output(data, fmt="text")
+    captured = capsys.readouterr()
+    assert "config:" in captured.out
+    assert "  target: 10.0.0.1" in captured.out
+    assert "  timeout: 30" in captured.out
+
+
+def test_format_text_default(capsys):
+    """Default format is text."""
+    data = {"key": "value"}
+    format_output(data)
+    captured = capsys.readouterr()
+    assert "key: value" in captured.out
+
+
+def test_format_invalid_raises():
+    """Invalid format should raise ValueError."""
+    with pytest.raises(ValueError, match="Unsupported output format"):
+        format_output({"a": 1}, fmt="xml")
+
+
+def test_format_json_non_serializable(capsys):
+    """JSON mode should handle non-serializable types via default=str."""
+    data = {"timestamp": object()}
+    format_output(data, fmt="json")
+    captured = capsys.readouterr()
+    parsed = json.loads(captured.out)
+    assert "timestamp" in parsed
+
+
+def test_no_logging_in_stdout(capsys):
+    """Neither text nor json mode should emit logging output to stdout."""
+    import logging
+    logger = logging.getLogger("matcha.output")
+    logger.warning("should go to stderr not stdout")
+    data = {"clean": True}
+    format_output(data, fmt="text")
+    captured = capsys.readouterr()
+    assert "should go to stderr" not in captured.out
+
+
+def test_format_text_empty_dict(capsys):
+    """Text mode handles an empty dict gracefully."""
+    format_output({}, fmt="text")
+    captured = capsys.readouterr()
+    assert captured.out == "\n"
+
+
+def test_format_json_empty_dict(capsys):
+    """JSON mode handles an empty dict."""
+    format_output({}, fmt="json")
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == {}


### PR DESCRIPTION
## Summary
- Add `matcha/output.py` with `format_output(data, fmt)` function that renders attack result dicts as human-readable text (key-value pairs, tables for list-of-dicts) or raw JSON to stdout
- All logging goes to stderr, keeping stdout clean for structured output
- 11 new tests covering text mode, JSON mode, tables, nested dicts, edge cases, and invalid format handling

## Test plan
- [x] `format_output(data, fmt="text")` prints readable summary to stdout
- [x] `format_output(data, fmt="json")` prints valid JSON to stdout
- [x] No logging output mixed into stdout
- [x] All 21 tests pass (11 new + 10 existing)

Closes #6