### PR TITLE
feat(cli): implement matcha list command (#7)

### DIFF
--- a/matcha/cli.py
+++ b/matcha/cli.py
@@ -7,6 +7,7 @@ import sys
 import click
 
 from matcha import __version__
+from matcha.commands.list_cmd import list_cmd
 
 
 @click.group(invoke_without_command=True)
@@ -50,6 +51,9 @@ def cli(ctx, verbose, output, no_color):
 
     if ctx.invoked_subcommand is None:
         click.echo(ctx.get_help())
+
+
+cli.add_command(list_cmd)
 
 
 if __name__ == "__main__":

--- a/matcha/commands/__init__.py
+++ b/matcha/commands/__init__.py
@@ -1,0 +1,1 @@
+"""matcha CLI sub-commands."""

--- a/matcha/commands/list_cmd.py
+++ b/matcha/commands/list_cmd.py
@@ -1,0 +1,114 @@
+"""``matcha list`` command -- display all available attacks grouped by category."""
+
+from __future__ import annotations
+
+import json
+import sys
+from typing import Any, Dict, List
+
+import click
+
+# ---------------------------------------------------------------------------
+# Attack catalog
+# ---------------------------------------------------------------------------
+# Each entry is (name, one-line description).
+# Grouped into the three categories defined by the project spec.
+
+NETWORK_LAYER: List[Dict[str, str]] = [
+    {"name": "arp-spoof", "description": "Perform ARP spoofing attack"},
+    {"name": "bgp-hijacking", "description": "Perform BGP hijacking simulation"},
+    {"name": "dhcp-starvation", "description": "Perform DHCP starvation attack"},
+    {"name": "dns-amplification", "description": "Perform DNS amplification attack"},
+    {"name": "icmp-flood", "description": "Perform ICMP flood attack (Ping Flood)"},
+    {"name": "mac-flooding", "description": "Perform MAC flooding attack"},
+    {"name": "mitm", "description": "Perform Man-in-the-Middle attack using ARP spoofing"},
+    {"name": "ntp-amplification", "description": "Perform NTP amplification attack"},
+    {"name": "ping-of-death", "description": "Perform Ping of Death attack"},
+    {"name": "smurf-attack", "description": "Perform Smurf amplification attack"},
+    {"name": "syn-flood", "description": "Perform SYN flood attack"},
+    {"name": "udp-flood", "description": "Perform UDP flood attack"},
+]
+
+APPLICATION_LAYER: List[Dict[str, str]] = [
+    {"name": "credential-harvester", "description": "Perform credential harvesting attack"},
+    {"name": "directory-traversal", "description": "Perform directory traversal attack"},
+    {"name": "ftp-brute-force", "description": "Perform FTP brute force attack"},
+    {"name": "http-dos", "description": "Perform HTTP DoS attack"},
+    {"name": "http-flood", "description": "Perform HTTP flood attack"},
+    {"name": "rdp-brute-force", "description": "Perform RDP brute force attack"},
+    {"name": "slowloris", "description": "Perform Slowloris attack"},
+    {"name": "sql-injection", "description": "Perform SQL injection attack"},
+    {"name": "ssh-brute-force", "description": "Perform SSH brute force attack"},
+    {"name": "ssl-strip", "description": "Perform SSL Strip attack"},
+    {"name": "vlan-hopping", "description": "Perform VLAN hopping attack"},
+    {"name": "xss", "description": "Perform XSS vulnerability testing"},
+    {"name": "xxe", "description": "Perform XXE attack"},
+]
+
+REPLAY: List[Dict[str, str]] = [
+    {"name": "pcap-replay", "description": "Replay captured network traffic from PCAP files"},
+]
+
+CATEGORIES: List[Dict[str, Any]] = [
+    {"category": "Network-layer", "attacks": NETWORK_LAYER},
+    {"category": "Application-layer", "attacks": APPLICATION_LAYER},
+    {"category": "Replay", "attacks": REPLAY},
+]
+
+
+def _total_attacks() -> int:
+    return sum(len(c["attacks"]) for c in CATEGORIES)
+
+
+# ---------------------------------------------------------------------------
+# Text formatter
+# ---------------------------------------------------------------------------
+
+def _format_text() -> str:
+    """Return a human-readable categorized attack list."""
+    lines: list[str] = []
+    for cat in CATEGORIES:
+        header = f"{cat['category']} ({len(cat['attacks'])} attacks)"
+        lines.append(header)
+        lines.append("-" * len(header))
+        for atk in cat["attacks"]:
+            lines.append(f"  {atk['name']:25s} {atk['description']}")
+        lines.append("")
+    lines.append(f"Total: {_total_attacks()} attacks")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# JSON formatter
+# ---------------------------------------------------------------------------
+
+def _format_json() -> str:
+    """Return the attack catalog as a JSON string."""
+    payload: list[dict[str, Any]] = []
+    for cat in CATEGORIES:
+        for atk in cat["attacks"]:
+            payload.append(
+                {
+                    "name": atk["name"],
+                    "category": cat["category"],
+                    "description": atk["description"],
+                }
+            )
+    return json.dumps(payload, indent=2)
+
+
+# ---------------------------------------------------------------------------
+# Click command
+# ---------------------------------------------------------------------------
+
+@click.command("list")
+@click.pass_context
+def list_cmd(ctx: click.Context) -> None:
+    """List all available attacks grouped by category."""
+    fmt = ctx.obj.get("output", "text")
+    if fmt == "json":
+        sys.stdout.write(_format_json())
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(_format_text())
+        sys.stdout.write("\n")

--- a/tests/test_list_cmd.py
+++ b/tests/test_list_cmd.py
@@ -1,0 +1,158 @@
+"""Tests for the ``matcha list`` command."""
+
+import json
+
+from click.testing import CliRunner
+
+from matcha.cli import cli
+from matcha.commands.list_cmd import (
+    APPLICATION_LAYER,
+    CATEGORIES,
+    NETWORK_LAYER,
+    REPLAY,
+    _format_json,
+    _format_text,
+    _total_attacks,
+)
+
+
+# ---------------------------------------------------------------------------
+# Catalog integrity
+# ---------------------------------------------------------------------------
+
+def test_total_attack_count():
+    """The catalog must contain exactly 26 attacks."""
+    assert _total_attacks() == 26
+
+
+def test_network_layer_count():
+    """Network-layer category should have 12 attacks."""
+    assert len(NETWORK_LAYER) == 12
+
+
+def test_application_layer_count():
+    """Application-layer category should have 13 attacks."""
+    assert len(APPLICATION_LAYER) == 13
+
+
+def test_replay_count():
+    """Replay category should have 1 attack."""
+    assert len(REPLAY) == 1
+
+
+def test_no_duplicate_names():
+    """Attack names must be unique across all categories."""
+    all_names = [
+        atk["name"] for cat in CATEGORIES for atk in cat["attacks"]
+    ]
+    assert len(all_names) == len(set(all_names))
+
+
+# ---------------------------------------------------------------------------
+# Text output
+# ---------------------------------------------------------------------------
+
+def test_format_text_contains_categories():
+    """Text output should include each category header."""
+    text = _format_text()
+    assert "Network-layer" in text
+    assert "Application-layer" in text
+    assert "Replay" in text
+
+
+def test_format_text_contains_total():
+    """Text output should show the total attack count."""
+    text = _format_text()
+    assert "Total: 26 attacks" in text
+
+
+def test_format_text_contains_all_attacks():
+    """Every attack name must appear in the text output."""
+    text = _format_text()
+    for cat in CATEGORIES:
+        for atk in cat["attacks"]:
+            assert atk["name"] in text
+
+
+# ---------------------------------------------------------------------------
+# JSON output
+# ---------------------------------------------------------------------------
+
+def test_format_json_valid():
+    """JSON output must be valid JSON."""
+    raw = _format_json()
+    payload = json.loads(raw)
+    assert isinstance(payload, list)
+
+
+def test_format_json_count():
+    """JSON output should have exactly 26 entries."""
+    payload = json.loads(_format_json())
+    assert len(payload) == 26
+
+
+def test_format_json_entry_keys():
+    """Each JSON entry must have name, category, and description."""
+    payload = json.loads(_format_json())
+    for entry in payload:
+        assert "name" in entry
+        assert "category" in entry
+        assert "description" in entry
+
+
+def test_format_json_categories():
+    """JSON entries should only belong to known categories."""
+    allowed = {"Network-layer", "Application-layer", "Replay"}
+    payload = json.loads(_format_json())
+    for entry in payload:
+        assert entry["category"] in allowed
+
+
+# ---------------------------------------------------------------------------
+# CLI integration via Click CliRunner
+# ---------------------------------------------------------------------------
+
+def test_cli_list_text():
+    """``matcha list`` should print categorized text output."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["list"])
+    assert result.exit_code == 0
+    assert "Network-layer" in result.output
+    assert "Application-layer" in result.output
+    assert "Replay" in result.output
+    assert "Total: 26 attacks" in result.output
+
+
+def test_cli_list_json():
+    """``matcha -o json list`` should print valid JSON array."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["-o", "json", "list"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert isinstance(payload, list)
+    assert len(payload) == 26
+
+
+def test_cli_list_json_long_flag():
+    """``matcha --output json list`` should also work."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--output", "json", "list"])
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    assert len(payload) == 26
+
+
+def test_cli_list_help():
+    """``matcha list --help`` should show help text."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["list", "--help"])
+    assert result.exit_code == 0
+    assert "List all available attacks" in result.output
+
+
+def test_cli_help_shows_list():
+    """``matcha --help`` should mention the list subcommand."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    assert "list" in result.output


### PR DESCRIPTION
## Summary

- Add `matcha list` command that displays all 26 available attacks grouped by category (Network-layer, Application-layer, Replay)
- Respect `--output json` global flag for machine-readable JSON array output
- Create `matcha/commands/` package with `list_cmd.py` module and register it in the CLI entry point

Closes #7

## Test plan

- [x] `matcha list` prints categorized attack list with all 26 attacks
- [x] `matcha -o json list` prints valid JSON array with 26 entries
- [x] All 38 tests pass (17 new + 21 existing)
- [ ] Verify `matcha list --help` shows command description