### PR TITLE
feat(cli): wire all 13 application-layer attacks via command factory (#14)

### DIFF
--- a/matcha/cli.py
+++ b/matcha/cli.py
@@ -10,7 +10,7 @@ from matcha import __version__
 from matcha.commands.factory import make_command
 from matcha.commands.info_cmd import info_cmd
 from matcha.commands.list_cmd import list_cmd
-from matcha.registry import CATEGORY_NETWORK, list_attacks
+from matcha.registry import CATEGORY_APPLICATION, CATEGORY_NETWORK, list_attacks
 
 
 @click.group(invoke_without_command=True)
@@ -59,9 +59,10 @@ def cli(ctx, verbose, output, no_color):
 cli.add_command(info_cmd)
 cli.add_command(list_cmd)
 
-# Auto-wire all network-layer attack commands from the registry.
-for _entry in list_attacks().get(CATEGORY_NETWORK, []):
-    cli.add_command(make_command(_entry))
+# Auto-wire all attack commands from the registry.
+for _category in (CATEGORY_NETWORK, CATEGORY_APPLICATION):
+    for _entry in list_attacks().get(_category, []):
+        cli.add_command(make_command(_entry))
 
 
 if __name__ == "__main__":

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -166,3 +166,51 @@ def test_network_attacks_missing_required_args():
         assert result.exit_code == 2, (
             f"{name} should exit 2 without required args, got {result.exit_code}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Application-layer attack command smoke tests
+# ---------------------------------------------------------------------------
+
+APPLICATION_ATTACKS = [
+    "credential-harvester",
+    "directory-traversal",
+    "ftp-brute-force",
+    "http-dos",
+    "http-flood",
+    "rdp-brute-force",
+    "slowloris",
+    "sql-injection",
+    "ssh-brute-force",
+    "ssl-strip",
+    "vlan-hopping",
+    "xss",
+    "xxe",
+]
+
+
+def test_all_application_attacks_registered_as_subcommands():
+    """Every application-layer attack must appear as a CLI subcommand."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    for name in APPLICATION_ATTACKS:
+        assert name in result.output, f"{name} not found in CLI help output"
+
+
+def test_application_attack_help_exits_zero():
+    """``matcha <attack> --help`` exits 0 for every application-layer attack."""
+    runner = CliRunner()
+    for name in APPLICATION_ATTACKS:
+        result = runner.invoke(cli, [name, "--help"])
+        assert result.exit_code == 0, f"{name} --help exited with {result.exit_code}"
+
+
+def test_application_attacks_missing_required_args():
+    """Application attacks with required args should exit 2 when called bare."""
+    runner = CliRunner()
+    for name in APPLICATION_ATTACKS:
+        result = runner.invoke(cli, [name])
+        assert result.exit_code == 2, (
+            f"{name} should exit 2 without required args, got {result.exit_code}"
+        )


### PR DESCRIPTION
Closes #14

## Summary

- Add `CATEGORY_APPLICATION` to the existing factory loop in `cli.py`
- All 13 application-layer attacks are now available as CLI subcommands
- Added smoke tests for `--help` and missing required args for every application attack

## Approach

Minimal change: extended the existing category loop (from #13) to also iterate application-layer attacks. One import and one tuple entry added.

## Changes

| File | Change |
|------|--------|
| `matcha/cli.py` | Added `CATEGORY_APPLICATION` to factory wiring loop |
| `tests/test_cli.py` | Added 3 smoke tests covering all 13 application-layer attacks |

## Test Results

- Unit tests: 158 passed
- All 13 application attacks verified: `--help` exits 0, missing required args exits 2
- `matcha list` shows all 13 under "Application-layer" category
- QA cycles: 1

## Acceptance Criteria

- [x] `matcha <attack> --help` works for all 13 application-layer attacks
- [x] `matcha list` shows all 13 under "Application" category