### PR TITLE
feat(cli): wire pcap-replay and complete all 26 attack commands (#15)

### DIFF
--- a/matcha/cli.py
+++ b/matcha/cli.py
@@ -10,7 +10,12 @@ from matcha import __version__
 from matcha.commands.factory import make_command
 from matcha.commands.info_cmd import info_cmd
 from matcha.commands.list_cmd import list_cmd
-from matcha.registry import CATEGORY_APPLICATION, CATEGORY_NETWORK, list_attacks
+from matcha.registry import (
+    CATEGORY_APPLICATION,
+    CATEGORY_NETWORK,
+    CATEGORY_REPLAY,
+    list_attacks,
+)
 
 
 @click.group(invoke_without_command=True)
@@ -60,7 +65,7 @@ cli.add_command(info_cmd)
 cli.add_command(list_cmd)
 
 # Auto-wire all attack commands from the registry.
-for _category in (CATEGORY_NETWORK, CATEGORY_APPLICATION):
+for _category in (CATEGORY_NETWORK, CATEGORY_APPLICATION, CATEGORY_REPLAY):
     for _entry in list_attacks().get(_category, []):
         cli.add_command(make_command(_entry))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -214,3 +214,48 @@ def test_application_attacks_missing_required_args():
         assert result.exit_code == 2, (
             f"{name} should exit 2 without required args, got {result.exit_code}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Replay attack command smoke tests
+# ---------------------------------------------------------------------------
+
+REPLAY_ATTACKS = [
+    "pcap-replay",
+]
+
+
+def test_all_replay_attacks_registered_as_subcommands():
+    """Every replay attack must appear as a CLI subcommand."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["--help"])
+    assert result.exit_code == 0
+    for name in REPLAY_ATTACKS:
+        assert name in result.output, f"{name} not found in CLI help output"
+
+
+def test_replay_attack_help_exits_zero():
+    """``matcha <attack> --help`` exits 0 for every replay attack."""
+    runner = CliRunner()
+    for name in REPLAY_ATTACKS:
+        result = runner.invoke(cli, [name, "--help"])
+        assert result.exit_code == 0, f"{name} --help exited with {result.exit_code}"
+
+
+def test_pcap_replay_shows_expected_options():
+    """``matcha pcap-replay --help`` shows file, interface, speed options."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["pcap-replay", "--help"])
+    assert result.exit_code == 0
+    for flag in ["--pcap-file", "--interface", "--speed"]:
+        assert flag in result.output, f"{flag} not found in pcap-replay help"
+
+
+def test_replay_attacks_missing_required_args():
+    """Replay attacks with required args should exit 2 when called bare."""
+    runner = CliRunner()
+    for name in REPLAY_ATTACKS:
+        result = runner.invoke(cli, [name])
+        assert result.exit_code == 2, (
+            f"{name} should exit 2 without required args, got {result.exit_code}"
+        )


### PR DESCRIPTION
Closes #15

## Summary

- Add `CATEGORY_REPLAY` to the factory wiring loop in `cli.py`, completing all 26 attack commands
- `mitm` was already wired as part of Network-layer in #13 — no additional work needed
- `pcap-replay` is the final attack, now available via `matcha pcap-replay`

## Approach

Extended the existing category tuple to include `CATEGORY_REPLAY`. One import and one tuple entry.

## Changes

| File | Change |
|------|--------|
| `matcha/cli.py` | Added `CATEGORY_REPLAY` to factory wiring loop |
| `tests/test_cli.py` | Added 4 smoke tests for pcap-replay (subcommand registration, --help, options, missing args) |

## Test Results

- Unit tests: 162 passed
- pcap-replay verified: `--help` shows `--pcap-file`, `--interface`, `--speed` options
- `matcha list` shows pcap-replay under "Replay" category
- All 26 attacks now wired as CLI subcommands
- QA cycles: 1

## Acceptance Criteria

- [x] `matcha pcap-replay --help` shows all options (file, interface, speed)
- [x] `matcha mitm --help` works (already wired in #13)
- [x] `matcha list` shows both under appropriate categories