### PR TITLE
feat(factory): add semantic input validation for all attack params (#16)

### DIFF
--- a/matcha/commands/factory.py
+++ b/matcha/commands/factory.py
@@ -9,10 +9,12 @@ formatting.
 from __future__ import annotations
 
 import importlib
+import ipaddress
 import logging
 import os
 import sys
 from typing import Any, Dict
+from urllib.parse import urlparse
 
 import click
 
@@ -37,6 +39,80 @@ _CLICK_TYPES: Dict[str, click.ParamType] = {
 # ---------------------------------------------------------------------------
 
 
+def _validate_ip(value: str) -> str | None:
+    """Return an error string if *value* is not a valid IP address."""
+    try:
+        ipaddress.ip_address(value)
+    except ValueError:
+        return f"Invalid IP address: {value}"
+    return None
+
+
+def _validate_port(value: int) -> str | None:
+    """Return an error string if *value* is outside the valid port range."""
+    if not (0 <= value <= 65535):
+        return f"Invalid port number: {value} (must be 0-65535)"
+    return None
+
+
+def _validate_url(value: str) -> str | None:
+    """Return an error string if *value* is not a valid HTTP(S) URL."""
+    parsed = urlparse(value)
+    if parsed.scheme not in ("http", "https"):
+        return f"Invalid URL scheme: {parsed.scheme!r} (expected http or https)"
+    if not parsed.netloc:
+        return f"Invalid URL (missing hostname): {value}"
+    return None
+
+
+def _validate_file_path(value: str) -> str | None:
+    """Return an error string if *value* does not point to a readable file."""
+    if not os.path.exists(value):
+        return f"File not found: {value}"
+    if not os.access(value, os.R_OK):
+        return f"File not readable: {value}"
+    return None
+
+
+def _validate_network(value: str) -> str | None:
+    """Return an error string if *value* is not valid CIDR notation."""
+    try:
+        ipaddress.ip_network(value, strict=False)
+    except ValueError:
+        return f"Invalid network (CIDR notation expected): {value}"
+    return None
+
+
+# Maps parameter name patterns to their semantic validator.
+# Checked in order — first match wins.
+_PARAM_VALIDATORS = [
+    # Exact name matches first
+    ("target_prefix", _validate_network),
+    # Suffix-based patterns
+    ("_ip", _validate_ip),
+    ("_port", _validate_port),
+    ("_url", _validate_url),
+    ("_file", _validate_file_path),
+    ("wordlist", _validate_file_path),
+]
+
+# Params matched by exact name (not suffix)
+_EXACT_NAME_VALIDATORS: Dict[str, Any] = {
+    "target_prefix": _validate_network,
+    "wordlist": _validate_file_path,
+}
+
+
+def _get_semantic_validator(name: str):
+    """Return the semantic validation function for a param *name*, or None."""
+    if name in _EXACT_NAME_VALIDATORS:
+        return _EXACT_NAME_VALIDATORS[name]
+    for suffix, validator in _PARAM_VALIDATORS:
+        if name.endswith(suffix):
+            return validator
+    return None
+
+
 def validate_params(
     entry: AttackEntry,
     values: Dict[str, Any],
@@ -47,20 +123,40 @@ def validate_params(
     * Required parameters are present and not ``None``.
     * ``int`` / ``float`` values are the correct type (Click normally
       handles this, but we double-check for safety).
+    * Semantic validation: IP addresses, ports, URLs, file paths, and
+      network prefixes are validated based on parameter name patterns.
     """
     errors: list[str] = []
     for pdef in entry.params:
         val = values.get(pdef.name)
+        cli_flag = f"--{pdef.name.replace('_', '-')}"
+
+        # Required check
         if pdef.required and val is None:
-            cli_flag = f"--{pdef.name.replace('_', '-')}"
             errors.append(f"Missing required option: {cli_flag}")
-        elif val is not None and pdef.type in ("int", "float"):
+            continue
+
+        # Skip further checks if value is absent (optional + not provided)
+        if val is None:
+            continue
+
+        # Basic type check
+        if pdef.type in ("int", "float"):
             expected = int if pdef.type == "int" else float
             if not isinstance(val, expected):
                 errors.append(
-                    f"Option --{pdef.name.replace('_', '-')}: "
+                    f"Option {cli_flag}: "
                     f"expected {pdef.type}, got {type(val).__name__}"
                 )
+                continue
+
+        # Semantic validation
+        validator = _get_semantic_validator(pdef.name)
+        if validator is not None:
+            err = validator(val)
+            if err is not None:
+                errors.append(f"Option {cli_flag}: {err}")
+
     return errors
 
 

--- a/tests/test_factory.py
+++ b/tests/test_factory.py
@@ -363,8 +363,11 @@ class TestMakeCommandExecution:
         _, kwargs = mock_cls.call_args
         assert kwargs["verbose_mode"] is False
 
-    def test_float_param_forwarded(self):
+    def test_float_param_forwarded(self, tmp_path):
         """Float params should be correctly typed."""
+        pcap = tmp_path / "test.pcap"
+        pcap.write_bytes(b"")
+
         entry = _float_entry()
         cmd = make_command(entry)
         group = _wrap_in_group(cmd)
@@ -374,7 +377,7 @@ class TestMakeCommandExecution:
             runner = CliRunner()
             runner.invoke(
                 group,
-                ["float-attack", "--pcap-file", "/tmp/test.pcap", "--speed", "2.5"],
+                ["float-attack", "--pcap-file", str(pcap), "--speed", "2.5"],
             )
 
         _, kwargs = mock_cls.call_args
@@ -430,6 +433,141 @@ class TestValidateParams:
         entry = _multi_required_entry()
         errors = validate_params(entry, {"target_url": None, "parameter": None})
         assert len(errors) == 2
+
+
+# ---------------------------------------------------------------------------
+# validate_params -- semantic validation
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticValidation:
+    """Tests for IP, port, URL, file path, and network validation."""
+
+    def test_invalid_ip_reports_error(self):
+        entry = _simple_entry()
+        errors = validate_params(entry, {"target_ip": "not-an-ip", "count": 100})
+        assert len(errors) == 1
+        assert "Invalid IP" in errors[0]
+
+    def test_valid_ip_no_error(self):
+        entry = _simple_entry()
+        errors = validate_params(entry, {"target_ip": "192.168.1.1", "count": 100})
+        assert errors == []
+
+    def test_valid_ipv6_no_error(self):
+        entry = _simple_entry()
+        errors = validate_params(entry, {"target_ip": "::1", "count": 100})
+        assert errors == []
+
+    def test_invalid_url_scheme(self):
+        entry = _multi_required_entry()
+        errors = validate_params(
+            entry, {"target_url": "ftp://bad.example.com", "parameter": "id"}
+        )
+        assert len(errors) == 1
+        assert "Invalid URL scheme" in errors[0]
+
+    def test_invalid_url_missing_host(self):
+        entry = _multi_required_entry()
+        errors = validate_params(entry, {"target_url": "http://", "parameter": "id"})
+        assert len(errors) == 1
+        assert "missing hostname" in errors[0]
+
+    def test_valid_url_no_error(self):
+        entry = _multi_required_entry()
+        errors = validate_params(
+            entry, {"target_url": "https://example.com/login", "parameter": "id"}
+        )
+        assert errors == []
+
+    def test_invalid_port_too_high(self):
+        entry = AttackEntry(
+            name="port-test",
+            description="Test",
+            category="Network-layer",
+            module_path="scripts.fake.fake",
+            class_name="Fake",
+            params=[ParamDef("target_port", "int", True, None, "Port")],
+        )
+        errors = validate_params(entry, {"target_port": 99999})
+        assert len(errors) == 1
+        assert "Invalid port" in errors[0]
+
+    def test_valid_port_no_error(self):
+        entry = AttackEntry(
+            name="port-test",
+            description="Test",
+            category="Network-layer",
+            module_path="scripts.fake.fake",
+            class_name="Fake",
+            params=[ParamDef("target_port", "int", False, 80, "Port")],
+        )
+        errors = validate_params(entry, {"target_port": 443})
+        assert errors == []
+
+    def test_file_not_found(self):
+        entry = _float_entry()
+        errors = validate_params(
+            entry, {"pcap_file": "/nonexistent/file.pcap", "speed": 1.0}
+        )
+        assert len(errors) == 1
+        assert "File not found" in errors[0]
+
+    def test_valid_file(self, tmp_path):
+        pcap = tmp_path / "test.pcap"
+        pcap.write_bytes(b"")
+        entry = _float_entry()
+        errors = validate_params(entry, {"pcap_file": str(pcap), "speed": 1.0})
+        assert errors == []
+
+    def test_network_prefix_invalid(self):
+        entry = AttackEntry(
+            name="net-test",
+            description="Test",
+            category="Network-layer",
+            module_path="scripts.fake.fake",
+            class_name="Fake",
+            params=[ParamDef("target_prefix", "str", True, None, "Prefix")],
+        )
+        errors = validate_params(entry, {"target_prefix": "not-cidr"})
+        assert len(errors) == 1
+        assert "Invalid network" in errors[0]
+
+    def test_network_prefix_valid(self):
+        entry = AttackEntry(
+            name="net-test",
+            description="Test",
+            category="Network-layer",
+            module_path="scripts.fake.fake",
+            class_name="Fake",
+            params=[ParamDef("target_prefix", "str", True, None, "Prefix")],
+        )
+        errors = validate_params(entry, {"target_prefix": "192.168.0.0/24"})
+        assert errors == []
+
+    def test_optional_none_skips_semantic_validation(self):
+        """Optional params with None value should not be validated."""
+        entry = _float_entry()
+        errors = validate_params(entry, {"pcap_file": "/dev/null", "speed": None})
+        assert errors == []
+
+    def test_wordlist_param_validates_as_file(self):
+        entry = AttackEntry(
+            name="brute-test",
+            description="Test",
+            category="Application-layer",
+            module_path="scripts.fake.fake",
+            class_name="Fake",
+            params=[
+                ParamDef("target_ip", "str", True, None, "IP"),
+                ParamDef("wordlist", "str", True, None, "Wordlist file"),
+            ],
+        )
+        errors = validate_params(
+            entry, {"target_ip": "10.0.0.1", "wordlist": "/no/such/file.txt"}
+        )
+        assert len(errors) == 1
+        assert "File not found" in errors[0]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #16

## Summary

Integrate semantic input validation into the command factory so every attack validates inputs before execution. Validation is pattern-matched by parameter name — no changes needed to the registry or individual attack scripts.

## Approach

Added lightweight validation functions directly in `factory.py` (IP, port, URL, file path, CIDR network) that are matched to parameters by name pattern (e.g. `*_ip` → IP validation, `*_url` → URL validation, `*_file`/`wordlist` → file path). This avoids a runtime dependency on `netifaces` (which `AttackValidator` requires) and keeps validation fast and self-contained.

## Changes

| File | Change |
|------|--------|
| `matcha/commands/factory.py` | Added 5 semantic validators + name-pattern matching in `validate_params()` |
| `tests/test_factory.py` | Added 14 tests for semantic validation (IP, URL, port, file, network, edge cases) |

## Test Results

- Unit tests: 176 passed
- Semantic validation: 14 new tests covering all 5 validation types
- QA cycles: 1

## Acceptance Criteria

- [x] `matcha syn-flood --target-ip not-an-ip` → exit 2 with "Invalid IP address" message
- [x] `matcha http-dos --target-url ftp://bad` → exit 2 with "Invalid URL scheme" message
- [x] `matcha pcap-replay --pcap-file /nonexistent.pcap` → exit 2 with "File not found" message