### PR TITLE
feat(cli): add __main__.py for python -m matcha (#18)

### DIFF
--- a/matcha/__main__.py
+++ b/matcha/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running matcha as ``python -m matcha``."""
+
+from matcha.cli import cli
+
+cli()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,8 @@
 """Smoke tests for the matcha CLI."""
 
 import logging
+import subprocess
+import sys
 
 from click.testing import CliRunner
 
@@ -13,6 +15,35 @@ def test_version():
     result = runner.invoke(cli, ["--version"])
     assert result.exit_code == 0
     assert __version__ in result.output
+
+
+# ---------------------------------------------------------------------------
+# python -m matcha smoke tests
+# ---------------------------------------------------------------------------
+
+
+def test_python_m_matcha_help():
+    """``python -m matcha --help`` must exit 0 and show usage text."""
+    result = subprocess.run(
+        [sys.executable, "-m", "matcha", "--help"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    assert "matcha" in result.stdout.lower()
+
+
+def test_python_m_matcha_version():
+    """``python -m matcha --version`` must exit 0 and print the version."""
+    result = subprocess.run(
+        [sys.executable, "-m", "matcha", "--version"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    assert result.returncode == 0
+    assert __version__ in result.stdout
 
 
 def test_help():


### PR DESCRIPTION
Closes #18

## Summary

- Create `matcha/__main__.py` so the CLI can be invoked as `python -m matcha`
- Add integration tests for `python -m matcha --help` and `python -m matcha --version`

## Approach

Minimal fix — single new file that imports and calls the existing Click CLI entry point.

## Changes

| File | Change |
|------|--------|
| `matcha/__main__.py` | New module entry point that imports and calls `cli()` |
| `tests/test_cli.py` | Add 2 subprocess-based integration tests for `python -m matcha` |

## Test Results

- Unit tests: 608 passed
- Build: passed
- QA cycles: 0 (trivial change, clean on first pass)

## Acceptance Criteria

- [x] `python -m matcha --help` works
- [x] `python -m matcha --version` works