### PR TITLE
feat(cli): add shell completions for bash/zsh/fish (#19)

### DIFF
--- a/matcha/cli.py
+++ b/matcha/cli.py
@@ -8,6 +8,7 @@ import click
 
 from matcha import __version__
 from matcha.commands.factory import make_command
+from matcha.commands.completions_cmd import completions_cmd
 from matcha.commands.info_cmd import info_cmd
 from matcha.commands.list_cmd import list_cmd
 from matcha.registry import (
@@ -61,6 +62,7 @@ def cli(ctx, verbose, output, no_color):
         click.echo(ctx.get_help())
 
 
+cli.add_command(completions_cmd)
 cli.add_command(info_cmd)
 cli.add_command(list_cmd)
 

--- a/matcha/commands/completions_cmd.py
+++ b/matcha/commands/completions_cmd.py
@@ -1,0 +1,24 @@
+"""``matcha completions`` command -- print shell completion activation scripts."""
+
+from __future__ import annotations
+
+import click
+
+_SHELLS = {
+    "bash": 'eval "$(_MATCHA_COMPLETE=bash_source matcha)"',
+    "zsh": 'eval "$(_MATCHA_COMPLETE=zsh_source matcha)"',
+    "fish": "_MATCHA_COMPLETE=fish_source matcha | source",
+}
+
+
+@click.command("completions")
+@click.argument("shell", type=click.Choice(sorted(_SHELLS), case_sensitive=False))
+def completions_cmd(shell: str) -> None:
+    """Print shell completion activation command.
+
+    Supported shells: bash, zsh, fish.
+
+    Add the printed command to your shell profile to enable tab-completion
+    for matcha.
+    """
+    click.echo(_SHELLS[shell])

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,6 +88,59 @@ def test_output_default_is_text():
     assert obj.get("output") == "text"
 
 
+# ---------------------------------------------------------------------------
+# Shell completions command smoke tests
+# ---------------------------------------------------------------------------
+
+
+def test_completions_bash():
+    """``matcha completions bash`` prints bash activation command."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["completions", "bash"])
+    assert result.exit_code == 0
+    assert "_MATCHA_COMPLETE=bash_source" in result.output
+
+
+def test_completions_zsh():
+    """``matcha completions zsh`` prints zsh activation command."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["completions", "zsh"])
+    assert result.exit_code == 0
+    assert "_MATCHA_COMPLETE=zsh_source" in result.output
+
+
+def test_completions_fish():
+    """``matcha completions fish`` prints fish activation command."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["completions", "fish"])
+    assert result.exit_code == 0
+    assert "_MATCHA_COMPLETE=fish_source" in result.output
+
+
+def test_completions_invalid_shell():
+    """``matcha completions powershell`` should fail with exit code 2."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["completions", "powershell"])
+    assert result.exit_code == 2
+
+
+def test_completions_no_arg():
+    """``matcha completions`` without a shell arg should fail."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["completions"])
+    assert result.exit_code == 2
+
+
+def test_completions_help():
+    """``matcha completions --help`` exits 0 and lists shells."""
+    runner = CliRunner()
+    result = runner.invoke(cli, ["completions", "--help"])
+    assert result.exit_code == 0
+    assert "bash" in result.output
+    assert "zsh" in result.output
+    assert "fish" in result.output
+
+
 def test_output_json():
     """--output json should be accepted."""
     runner = CliRunner()


### PR DESCRIPTION
Closes #19

## Summary

- Add `matcha completions <shell>` subcommand that prints the activation command for Click's built-in tab-completion
- Supports bash, zsh, and fish shells

## Approach

Minimal fix — new `completions_cmd.py` command registered in `cli.py`. Leverages Click's built-in `_MATCHA_COMPLETE` mechanism.

## Changes

| File | Change |
|------|--------|
| `matcha/commands/completions_cmd.py` | New command printing shell-specific activation scripts |
| `matcha/cli.py` | Import and register completions command |
| `tests/test_cli.py` | 6 tests covering bash/zsh/fish output, invalid shell, missing arg, help |

## Test Results

- Unit tests: 614 passed
- Build: passed
- QA cycles: 0 (trivial change, clean on first pass)

## Acceptance Criteria

- [x] `_MATCHA_COMPLETE=bash_source matcha` outputs valid bash completion script
- [x] `_MATCHA_COMPLETE=zsh_source matcha` outputs valid zsh completion script
- [x] `matcha completions bash` prints the activation command